### PR TITLE
Fixed error with document.styleSheets[i].cssRules

### DIFF
--- a/scripts/send_images.js
+++ b/scripts/send_images.js
@@ -13,17 +13,21 @@
     extractImagesFromStyles: function () {
       var imagesFromStyles = [];
       for (var i = 0; i < document.styleSheets.length; i++) {
-        var cssRules = document.styleSheets[i].cssRules;
-        if (cssRules) {
-          for (var j = 0; j < cssRules.length; j++) {
-            var style = cssRules[j].style;
-            if (style && style.backgroundImage) {
-              var url = imageDownloader.extractURLFromStyle(style.backgroundImage);
-              if (imageDownloader.isImageURL(url)) {
-                imagesFromStyles.push(url);
+        try {
+          var cssRules = document.styleSheets[i].cssRules;
+          if (cssRules) {
+            for (var j = 0; j < cssRules.length; j++) {
+              var style = cssRules[j].style;
+              if (style && style.backgroundImage) {
+                var url = imageDownloader.extractURLFromStyle(style.backgroundImage);
+                if (imageDownloader.isImageURL(url)) {
+                  imagesFromStyles.push(url);
+                }
               }
             }
           }
+        } catch(exception) {
+          // Exception suppressed
         }
       }
 


### PR DESCRIPTION
I noticed that a lot of the sites that I'm trying to use the Image Downloader on have their stylesheets hosted on a CDN, which is a different domain. Due to cross-domain rules in Chrome, those stylesheets don't appear to be readable anymore, for security purposes.

Adding the try/catch block will mean that the extension shouldn't break, but it does mean that users will miss out on images that are defined in a stylesheet hosted on a CDN (or another domain entirely).